### PR TITLE
TRI-3894 Add an option to skip storing test results

### DIFF
--- a/qase-pytest/src/qaseio/pytest/conftest.py
+++ b/qase-pytest/src/qaseio/pytest/conftest.py
@@ -83,6 +83,7 @@ def pytest_configure(config):
                     run_id=config.getoption("qase_testops_run_id", None),
                     plan_id=config.getoption("qase_testops_plan_id", None),
                     complete_run=config.getoption("qase_testops_run_complete", False),
+                    dont_publish_results=config.getoption("qase_testops_dont_publish_results", False),
                     bulk=config.getoption("qase_testops_bulk", True),
                     run_title=config.getoption("qase_testops_run_title", None),
                     host=config.getoption("qase_testops_api_host", "qase.io"),

--- a/qase-pytest/src/qaseio/pytest/options.py
+++ b/qase-pytest/src/qaseio/pytest/options.py
@@ -100,8 +100,18 @@ class QasePytestOptions:
         QasePytestOptions.add_option_ini(
             parser,
             group,
+            "--qase-testops-dont-publish-results",
+            dest="qase_testops_dont_publish_results",
+            type="bool",
+            default=False,
+            help="Do not publish test results",
+        )
+
+        QasePytestOptions.add_option_ini(
+            parser,
+            group,
             "--qase-testops-run-complete",
-            dest="qase_testops_run_description",
+            dest="qase_testops_run_complete",
             type="bool",
             default=False,
             help="Complete run after tests execution",

--- a/qase-python-commons/src/qaseio/commons/testops.py
+++ b/qase-python-commons/src/qaseio/commons/testops.py
@@ -46,6 +46,7 @@ class QaseTestOps:
             environment=None,
             host="qase.io",
             complete_run=False,
+            dont_publish_results=False,
             defect=False,
             chunk_size=200) -> None:
 
@@ -64,6 +65,7 @@ class QaseTestOps:
         self.bulk = parseBool(bulk)
         self.defect = parseBool(defect)
         self.complete_after_run = parseBool(complete_run)
+        self.dont_publish_results = parseBool(dont_publish_results)
         self.environment = None
         if environment:
             if isinstance(environment, str):
@@ -71,7 +73,7 @@ class QaseTestOps:
             elif isinstance(environment, int):
                 self.environment_id = environment
         self.host = host
-        self.enabled = True
+        self.enabled = not self.dont_publish_results
         self.chunk_size = min(2000, max(10, int(chunk_size)))
 
         if run_title and run_title != '':


### PR DESCRIPTION
This adds an option to select test cases to execute, but results are not pushed back into Qase.