### PR TITLE
Stability: Mark as known failed also errors that aren't assertions

### DIFF
--- a/qase-pytest/src/qaseio/pytest/plugin.py
+++ b/qase-pytest/src/qaseio/pytest/plugin.py
@@ -154,7 +154,10 @@ class QasePytestPlugin:
 
             if report.failed:
                 if call.excinfo.typename != "AssertionError":
-                    self.set_result("BROKEN")
+                    if not self.runtime.result.known_issue:
+                        self.set_result("BROKEN")
+                    else:
+                        self.set_result("FAILED")
                 else:
                     if self.mark_rerun and not self.runtime.result.known_issue:
                         self.set_result("RERUN")


### PR DESCRIPTION
We have at least cname redirect tests that are failing with HTTP Error 500 due to SOBI-8860, but I think that captive portal tests also aren't failing due to AssertionError.

Run with this change is here:
https://app.qase.io/run/RV/dashboard/982
https://jenkins-common.sso.plume.tech/common-plume-jenkins/job/QA/job/QA-FRV_CRV/job/Qqase_RV/1542/console