### PR TITLE
TRI-4990: report execution time for combined/merged test cases

### DIFF
--- a/qase-pytest/src/qaseio/pytest/plugin.py
+++ b/qase-pytest/src/qaseio/pytest/plugin.py
@@ -334,7 +334,6 @@ class QasePytestPlugin:
             self.runtime.result.merge_results = True
             self.runtime.result.merge_results_completed = False
 
-
     def _set_merge_results_completed(self, nextitem: pytest.Item) -> None:
         if not self.runtime.result.merge_results:
             return None

--- a/qase-python-commons/src/qaseio/commons/models/result.py
+++ b/qase-python-commons/src/qaseio/commons/models/result.py
@@ -133,6 +133,8 @@ class Result(object):
         return self.testops_id
 
     def get_duration(self) -> int:
+        if self.results_to_merge:
+            return sum([res.execution.duration for res in self.results_to_merge])
         return self.execution.duration
 
     def get_suite_title(self) -> Optional[str]:

--- a/qase-python-commons/src/qaseio/commons/testops.py
+++ b/qase-python-commons/src/qaseio/commons/testops.py
@@ -366,7 +366,7 @@ class QaseTestOps:
                         case_id=result.get_testops_id(),
                         status=result.execution.status,
                         stacktrace=result.execution.stacktrace,
-                        time_ms=result.execution.duration,
+                        time_ms=result.get_duration(),
                         comment=result.message,
                         attachments=[attach.hash for attach in attached],
                         defect=self.defect,
@@ -428,7 +428,7 @@ class QaseTestOps:
             return
         test_result.merge_results_completed = True
         # Sort subtests by their statuses. Worst result at the end.
-        item_executions =  [res_to_merge.execution for res_to_merge in test_result.results_to_merge]
+        item_executions = [res_to_merge.execution for res_to_merge in test_result.results_to_merge]
         subtests_status = [execution.status for execution in item_executions]
         subtests_status = list(set(subtests_status))
         subtests_status.sort(key=lambda subtest_status: QASE_STATUS_IDS[subtest_status])
@@ -483,7 +483,7 @@ class QaseTestOps:
 
     @staticmethod
     def merge_test_msg_report(test_result: Result):
-        item_messages =  [res_to_merge.message for res_to_merge in test_result.results_to_merge]
+        item_messages = [res_to_merge.message for res_to_merge in test_result.results_to_merge]
         main_test_message = test_result.message
         for item_msg in item_messages:
             if not item_msg:


### PR DESCRIPTION
where multiple functions or methods are aggregated under a single qase id.

Example result
Pytest execution time:
```
29 passed in 2431.72s (0:40:31)
```

is reported as:
![image](https://github.com/user-attachments/assets/4ec17103-e721-48eb-be82-452e5144ef1b)


**NOTE** Pre-test execution, including test collection and sorting is not included in execution time reported to qase. Same for pos-test execution work, like cleaning up temp files, printing out versions and test results - all happen outside of test execution. The execution time also doesn't account for the time needed to upload results to qase which happens between test cases, and at the end of test run.