### PR TITLE
TRI-5438: unpin a blocking dependency

### DIFF
--- a/qase-pytest/requirements.txt
+++ b/qase-pytest/requirements.txt
@@ -2,4 +2,4 @@ attrs==21.4.0
 cattrs==1.1.2
 pytest~=7.2.2
 qase-python-commons>=2.0.0,<2.1.0
-filelock==3.10.7
+filelock>=3.10.7


### PR DESCRIPTION
the way qase packaging is organized reads 'tell me that you don't know much about packaging without telling me that you don't know much about packaging'